### PR TITLE
Pass output images for filters and convertors as a reference

### DIFF
--- a/interfaces/api/image/IImageConvertor.h
+++ b/interfaces/api/image/IImageConvertor.h
@@ -21,8 +21,8 @@
 // part of Solar namespace //
 
 #include "IComponentIntrospect.h"
+#include "core/Messages.h"
 #include "datastructure/Image.h"
-
 
 namespace SolAR {
 using namespace datastructure;
@@ -40,8 +40,8 @@ public:
    /// \brief ~IImageConvertor
    ///
    virtual ~IImageConvertor() {};
-   virtual int convert(SRef<Image> imgSrc, SRef<Image>& imgDst) = 0;
-   virtual int convert(SRef<Image> imgSrc, SRef<Image>& imgDst, Image::ImageLayout destLayout) = 0;
+   virtual FrameworkReturnCode convert(SRef<Image> imgSrc, SRef<Image>& imgDst) = 0;
+   virtual FrameworkReturnCode convert(SRef<Image> imgSrc, SRef<Image>& imgDst, Image::ImageLayout destLayout) = 0;
 
    XPCF_DECLARE_UUID("9c982719-6cb4-4831-aa88-9e01afacbd16");
 };

--- a/interfaces/api/image/IImageFilter.h
+++ b/interfaces/api/image/IImageFilter.h
@@ -30,50 +30,50 @@ class IImageFilter : public virtual org::bcom::xpcf::IComponentIntrospect {
 public:
     IImageFilter() = default;
     virtual ~IImageFilter() = default;
-    virtual void threshold(SRef<Image>input,
-                           SRef<Image>output,
+    virtual FrameworkReturnCode threshold(SRef<Image>input,
+                           SRef<Image>& output,
                            int threshold) = 0;
 
-    virtual void binarize(SRef<Image>input,
-                          SRef<Image>output,
+    virtual FrameworkReturnCode binarize(SRef<Image>input,
+                          SRef<Image>& output,
                           int min,
                           int max) = 0;
 
-    virtual void adaptiveBinarize(SRef<Image>input,
-                   SRef<Image>output,
+    virtual FrameworkReturnCode adaptiveBinarize(SRef<Image>input,
+                   SRef<Image>& output,
                    int max,
                    int blockSize,
                    int C) = 0;
 
-    virtual void blur(SRef<Image>input,
-                    SRef<Image>output,
+    virtual FrameworkReturnCode blur(SRef<Image>input,
+                    SRef<Image>& output,
                     int kernerl_id,
                     int kernel_width,
                     int kernel_height,
                     int direction) = 0;
 
-   virtual  void gradient(SRef<Image>input,
-                          SRef<Image>output,
+   virtual  FrameworkReturnCode gradient(SRef<Image>input,
+                          SRef<Image>& output,
                           int x_order,
                           int y_order) = 0;
 
-  virtual  void laplacian(SRef<Image>input,
-                          SRef<Image>output,
+  virtual  FrameworkReturnCode laplacian(SRef<Image>input,
+                          SRef<Image>& output,
                           int method) = 0;
 
-  virtual  void erode(SRef<Image>input,
-                      SRef<Image>output,
+  virtual  FrameworkReturnCode erode(SRef<Image>input,
+                      SRef<Image>& output,
                       int erode_type,
                       int erode_size) = 0;
 
 
-  virtual   void dilate(SRef<Image>input,
-                        SRef<Image>output,
+  virtual   FrameworkReturnCode dilate(SRef<Image>input,
+                        SRef<Image>& output,
                         int dilate_type,
                         int dilate_size) = 0;
 
-  virtual   void equalize(SRef<Image>input,
-                          SRef<Image>output,
+  virtual   FrameworkReturnCode equalize(SRef<Image>input,
+                          SRef<Image>& output,
                           int method) = 0;
 
       XPCF_DECLARE_UUID("f7948ae2-e994-416f-be40-dd404ca03a83");

--- a/src/datastructure/Image.cpp
+++ b/src/datastructure/Image.cpp
@@ -56,9 +56,10 @@ void Image::ImageInternal::setBufferSize(uint32_t size)
     m_bufferSize = size;
     if (m_bufferSize == 0) { // invalid size
         return;
-    }
+    }    
     m_storageData.reserve(m_bufferSize);
-    memset(m_storageData.data(),0,m_bufferSize);
+    m_storageData.resize(m_bufferSize);
+    //memset(m_storageData.data(),0,m_bufferSize); // Normally not useful
 }
 
 void Image::ImageInternal::setData(void * data, uint32_t size)


### PR DESCRIPTION
Each conversion and filter method check if the output image is null. If it is the case, it allocates a SRef of the output image before filtering or converting the image.
Requiring to pass a reference on SRef<Image>& output.