### PR TITLE
add AKAZE2 keypoint type

### DIFF
--- a/interfaces/api/features/IKeypointDetector.h
+++ b/interfaces/api/features/IKeypointDetector.h
@@ -48,6 +48,7 @@ namespace features {
 		DAISY,
 		LATCH,
 		AKAZE,
+		AKAZE2,
 		AKAZEUP,
 		BRISK,
 		BRIEF,


### PR DESCRIPTION
Added AKAZE2 keypoint type (faster implementation). To be tested with SolARModuleOpencv/feature/BruteForceMatching and NaturalImageMarker/feature/AKAEZFeature