### PR TITLE
Make dtor of Trackable and Trackable2D non default

### DIFF
--- a/interfaces/datastructure/Trackable.h
+++ b/interfaces/datastructure/Trackable.h
@@ -56,9 +56,9 @@ class SOLARFRAMEWORK_API Trackable
         Trackable(const std::string & url);
 
         ///
-        /// @brief Trackable default destructor
+        /// @brief Trackable destructor
         ///
-        virtual ~Trackable() = default;
+        virtual ~Trackable();
 
         ///
         /// @brief Returns the type of the Trackable object

--- a/interfaces/datastructure/Trackable2D.h
+++ b/interfaces/datastructure/Trackable2D.h
@@ -51,9 +51,9 @@ class SOLARFRAMEWORK_API Trackable2D : virtual public Trackable {
         Trackable2D(const std::string & url, const float & width, const float & height);
 
         ///
-        /// @brief Trackable2D default destructor
+        /// @brief Trackable2D destructor
         ///
-        virtual ~Trackable2D() = default;
+        virtual ~Trackable2D();
 
         // Class methods
 

--- a/src/datastructure/Trackable.cpp
+++ b/src/datastructure/Trackable.cpp
@@ -27,6 +27,9 @@ Trackable::Trackable(const std::string & url) : m_url(url) {
     LOG_DEBUG("Trackable constructor with url = {}", url);
 }
 
+Trackable::~Trackable()
+{}
+
 std::string Trackable::getURL() const {
     return m_url;
 }

--- a/src/datastructure/Trackable2D.cpp
+++ b/src/datastructure/Trackable2D.cpp
@@ -39,6 +39,10 @@ Trackable2D::Trackable2D(const std::string & url,
     m_size.height = height;
 }
 
+// destructor
+Trackable2D::~Trackable2D()
+{}
+
 // Class methods
 
 Sizef Trackable2D::getSize() const {


### PR DESCRIPTION
These class must have virtual method with an implementation in
the cpp file in order to be able to use dynamic-cast.

fix SolarFramework/SolARUnityPlugin#5