### PR TITLE
Use XPCF_DEFINE_COMPONENT_TRAITS macro

### DIFF
--- a/interfaces/api/features/IImageMatcher.h
+++ b/interfaces/api/features/IImageMatcher.h
@@ -70,11 +70,9 @@ public:
 }
 }  // end of namespace SolAR
 
-template <> struct org::bcom::xpcf::InterfaceTraits<SolAR::api::features::IImageMatcher>
-{
-    static constexpr const char * UUID = "{157ec340-0682-4e6c-bf69-e4d95fa760d3}";
-    static constexpr const char * NAME = "IImageMatcher";
-    static constexpr const char * DESCRIPTION = "IImageMatcher interface description";
-};
+XPCF_DEFINE_INTERFACE_TRAITS(SolAR::api::input::features::IImageMatcher,
+                             "157ec340-0682-4e6c-bf69-e4d95fa760d3",
+                             "IImageMatcher",
+                             "IImageMatcher interface description");
 
 #endif // IIMAGEMATCHER_H

--- a/interfaces/api/input/devices/IDevice.h
+++ b/interfaces/api/input/devices/IDevice.h
@@ -57,11 +57,9 @@ public:
 }
 }
 
-template <> struct org::bcom::xpcf::InterfaceTraits<SolAR::api::input::devices::IDevice>
-{
-    static constexpr const char * UUID = "{d73c7b34-f6af-48f3-b65d-37a047929f4b}";
-    static constexpr const char * NAME = "IDevice";
-    static constexpr const char * DESCRIPTION = "IDevice interface description";
-};
+XPCF_DEFINE_INTERFACE_TRAITS(SolAR::api::input::devices::IDevice,
+                             "d73c7b34-f6af-48f3-b65d-37a047929f4b",
+                             "IDevice",
+                             "IDevice interface description");
 
 #endif // IDEVICE_H


### PR DESCRIPTION
use XPCF_DEFINE_COMPONENTS_TRAITS macro to remove traits from xpcf namespace.