### PR TITLE
return a value for IAsyncRelocalizationPipeline::relocalizeProcessRequest

### DIFF
--- a/interfaces/api/pipeline/IAsyncRelocalizationPipeline.h
+++ b/interfaces/api/pipeline/IAsyncRelocalizationPipeline.h
@@ -132,15 +132,15 @@ public:
                                                          MappingStatus & mappingStatus)
     {
         SolAR::datastructure::Transform3Df worldTransform(SolAR::datastructure::Maths::Matrix4f::Zero());
-        relocalizeProcessRequest(images,
-                                 poses,
-                                 /* fixedPose = */ false,
-                                 worldTransform,
-                                 timestamp,
-                                 transform3DStatus,
-                                 transform3D,
-                                 confidence,
-                                 mappingStatus);
+        return relocalizeProcessRequest(images,
+                                        poses,
+                                        /* fixedPose = */ false,
+                                        worldTransform,
+                                        timestamp,
+                                        transform3DStatus,
+                                        transform3D,
+                                        confidence,
+                                        mappingStatus);
     }
 
     /// @brief Request the asynchronous relocalization pipeline to process a new image to calculate


### PR DESCRIPTION
Visual 2019 raises an error as the function relocalizeProcessRequest does not return a value.
This fix should solve the issue.