### PR TITLE
Support stereo rectification with known camera extrinsics 

### DIFF
--- a/interfaces/api/input/devices/IStereoCameraCalibration.h
+++ b/interfaces/api/input/devices/IStereoCameraCalibration.h
@@ -50,13 +50,24 @@ public:
 	/// @param[out] rectParams1 Rectification parameters of the first camera
 	/// @param[out] rectParams2 Rectification parameters of the second camera
 	/// @return FrameworkReturnCode::_SUCCESS if calibration succeed, else FrameworkReturnCode::_ERROR_
-    virtual FrameworkReturnCode calibrate(const std::vector<SRef<SolAR::datastructure::Image>>& images1,
-                                          const std::vector<SRef<SolAR::datastructure::Image>>& images2,
-                                          const SolAR::datastructure::CameraParameters & camParams1,
-                                          const SolAR::datastructure::CameraParameters & camParams2,
-                                          SolAR::datastructure::Transform3Df & transformation,
-                                          SolAR::datastructure::RectificationParameters & rectParams1,
-                                          SolAR::datastructure::RectificationParameters & rectParams2) = 0;
+    virtual FrameworkReturnCode calibrate(const std::vector<SRef<datastructure::Image>> &images1,
+                                          const std::vector<SRef<datastructure::Image>> &images2,
+                                          const datastructure::CameraParameters &camParams1,
+                                          const datastructure::CameraParameters &camParams2,
+                                          datastructure::Transform3Df &transformation,
+                                          datastructure::RectificationParameters &rectParams1,
+                                          datastructure::RectificationParameters &rectParams2) = 0;
+
+    /// @brief Compute rectification parameters from stereo camera parameters
+    /// @param[in] camParams1 Intrinsics of the first camera
+    /// @param[in] camParams2 Intrinsics of the second camera
+    /// @param[out] rectParams1 Rectification parameters of the first camera
+    /// @param[out] rectParams2 Rectification parameters of the second camera
+    /// @return FrameworkReturnCode::_SUCCESS if calibration succeed, else FrameworkReturnCode::_ERROR_
+    virtual FrameworkReturnCode rectify(const datastructure::CameraParameters& camParams1,
+                                        const datastructure::CameraParameters& camParams2,
+                                        datastructure::RectificationParameters& rectParams1,
+                                        datastructure::RectificationParameters& rectParams2) = 0;
 };
 
 }

--- a/interfaces/api/input/devices/IStereoCameraCalibration.h
+++ b/interfaces/api/input/devices/IStereoCameraCalibration.h
@@ -50,13 +50,13 @@ public:
 	/// @param[out] rectParams1 Rectification parameters of the first camera
 	/// @param[out] rectParams2 Rectification parameters of the second camera
 	/// @return FrameworkReturnCode::_SUCCESS if calibration succeed, else FrameworkReturnCode::_ERROR_
-    virtual FrameworkReturnCode calibrate(const std::vector<SRef<datastructure::Image>> &images1,
-                                          const std::vector<SRef<datastructure::Image>> &images2,
-                                          const datastructure::CameraParameters &camParams1,
-                                          const datastructure::CameraParameters &camParams2,
-                                          datastructure::Transform3Df &transformation,
-                                          datastructure::RectificationParameters &rectParams1,
-                                          datastructure::RectificationParameters &rectParams2) = 0;
+    virtual FrameworkReturnCode calibrate(const std::vector<SRef<SolAR::datastructure::Image>> &images1,
+                                          const std::vector<SRef<SolAR::datastructure::Image>> &images2,
+                                          const SolAR::datastructure::CameraParameters &camParams1,
+                                          const SolAR::datastructure::CameraParameters &camParams2,
+                                          SolAR::datastructure::Transform3Df &transformation,
+                                          SolAR::datastructure::RectificationParameters &rectParams1,
+                                          SolAR::datastructure::RectificationParameters &rectParams2) = 0;
 
     /// @brief Compute rectification parameters from stereo camera parameters
     /// @param[in] camParams1 Intrinsics of the first camera
@@ -64,10 +64,10 @@ public:
     /// @param[out] rectParams1 Rectification parameters of the first camera
     /// @param[out] rectParams2 Rectification parameters of the second camera
     /// @return FrameworkReturnCode::_SUCCESS if calibration succeed, else FrameworkReturnCode::_ERROR_
-    virtual FrameworkReturnCode rectify(const datastructure::CameraParameters& camParams1,
-                                        const datastructure::CameraParameters& camParams2,
-                                        datastructure::RectificationParameters& rectParams1,
-                                        datastructure::RectificationParameters& rectParams2) = 0;
+    virtual FrameworkReturnCode rectify(const SolAR::datastructure::CameraParameters& camParams1,
+                                        const SolAR::datastructure::CameraParameters& camParams2,
+                                        SolAR::datastructure::RectificationParameters& rectParams1,
+                                        SolAR::datastructure::RectificationParameters& rectParams2) = 0;
 };
 
 }

--- a/interfaces/datastructure/CameraDefinitions.h
+++ b/interfaces/datastructure/CameraDefinitions.h
@@ -165,6 +165,7 @@ inline void serialize(Archive & ar,
     ar & parameters.resolution;
     ar & parameters.intrinsic;
     ar & parameters.distortion;
+    ar & parameters.extrinsics;
 }
 
 template<class Archive>
@@ -258,6 +259,7 @@ inline void to_json(BasicJsonType& j, const CameraParameters& camParams)
     j["resolution"]["height"] = camParams.resolution.height;
     j["intrinsic"] = camParams.intrinsic;
     j["distortion"] = camParams.distortion;
+    j["extrinsics"] = camParams.extrinsics;
 }
 
 template <typename BasicJsonType>
@@ -270,6 +272,7 @@ inline void from_json(BasicJsonType& j, CameraParameters& camParams)
     camParams.resolution.height = j["resolution"]["height"].template get<uint32_t>();
     camParams.intrinsic = j["intrinsic"].template get<CamCalibration>();
     camParams.distortion = j["distortion"].template get<CamDistortion>();
+    camParams.extrinsics = j["extrinsics"].template get<CamExtrinsics>();
 }
 
 template <typename BasicJsonType>

--- a/interfaces/datastructure/CameraDefinitions.h
+++ b/interfaces/datastructure/CameraDefinitions.h
@@ -59,6 +59,14 @@ typedef Maths::Matrix<float, 3, 3, Eigen::RowMajor> CamCalibration;
  */
 typedef Maths::Matrix<float, 5, 1> CamDistortion;
 
+/**
+ * @typedef CamExtrinsics
+ * @brief <B>A 3D transform defining the extrinsics of a camera in a rig.</B>
+ *
+ * Camera extrinsics is defined with a 4x4 matrix that describe a transformation in 3D space (3D rotation + translation).
+*/
+typedef Transform3Df CamExtrinsics;
+
 //Pose matrix definition               Vector defintion
 //
 //  R1x1    R1x2    R1x3    Tx         | X |
@@ -106,7 +114,8 @@ struct CameraParameters
     CameraType type;
     Sizei resolution;
     CamCalibration intrinsic;
-    CamDistortion distortion;    
+    CamDistortion distortion;
+    CamExtrinsics extrinsics;
 };
 
 /**


### PR DESCRIPTION
- Add field `extrinsics` of type `Transform3Df` to `CameraParameters` struct
- Add `IStereoCameraCalibration::rectify()` API