### PR TITLE
feat: remove reference to _BCOM_SHARED macro

### DIFF
--- a/SolARFramework.pro
+++ b/SolARFramework.pro
@@ -39,10 +39,6 @@ PROJECTCONFIG = QTVS
 #NOTE : CONFIG as staticlib or sharedlib, DEPENDENCIESCONFIG as staticlib or sharedlib, QMAKE_TARGET.arch and PROJECTDEPLOYDIR MUST BE DEFINED BEFORE templatelibconfig.pri inclusion
 include ($$shell_quote($$shell_path($${QMAKE_REMAKEN_RULES_ROOT}/templatelibconfig.pri)))  # Shell_quote & shell_path required for visual on windows
 
-msvc {
-DEFINES += "_BCOM_SHARED=__declspec(dllexport)"
-}
-
 include (SolARFramework.pri)
 
 # DEFINES += XPCF_DISABLE_ATTRIBUTES

--- a/interfaces/api/features/ICornerRefinement.h
+++ b/interfaces/api/features/ICornerRefinement.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ICORNERREFINEMENT_H
 #define SOLAR_ICORNERREFINEMENT_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <vector>
 #include "core/Messages.h"
 #include "datastructure/Image.h"

--- a/interfaces/api/features/IDescriptorMatcher.h
+++ b/interfaces/api/features/IDescriptorMatcher.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_IDESCRIPTORMATCHER_H
 #define SOLAR_IDESCRIPTORMATCHER_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <vector>
 #include "datastructure/DescriptorBuffer.h"
 #include "datastructure/DescriptorMatch.h"

--- a/interfaces/api/features/IDescriptorMatcherGeometric.h
+++ b/interfaces/api/features/IDescriptorMatcherGeometric.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_IDESCRIPTORMATCHERGEOMETRIC_H
 #define SOLAR_IDESCRIPTORMATCHERGEOMETRIC_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <vector>
 #include "datastructure/DescriptorBuffer.h"
 #include "datastructure/DescriptorMatch.h"

--- a/interfaces/api/features/IDescriptorMatcherRegion.h
+++ b/interfaces/api/features/IDescriptorMatcherRegion.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_IDESCRIPTORMATCHERREGION_H
 #define SOLAR_IDESCRIPTORMATCHERREGION_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <vector>
 #include "datastructure/DescriptorBuffer.h"
 #include "datastructure/DescriptorMatch.h"

--- a/interfaces/api/features/IDescriptorsExtractor.h
+++ b/interfaces/api/features/IDescriptorsExtractor.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_IDESCRIPTORSEXTRACTOR_H
 #define SOLAR_IDESCRIPTORSEXTRACTOR_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <vector>
 #include "datastructure/Keypoint.h"
 //#include "IDescriptor.h"

--- a/interfaces/api/features/IDescriptorsExtractorFromImage.h
+++ b/interfaces/api/features/IDescriptorsExtractorFromImage.h
@@ -17,10 +17,6 @@
 #ifndef IDescriptorsExtractorFromImageFROMIMAGE_H
 #define IDescriptorsExtractorFromImageFROMIMAGE_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <vector>
 #include "datastructure/Keypoint.h"
 #include "datastructure/Image.h"

--- a/interfaces/api/features/IKeypointDetector.h
+++ b/interfaces/api/features/IKeypointDetector.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_IKEYPOINTDETECTOR_H
 #define SOLAR_IKEYPOINTDETECTOR_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <memory>
 #include <vector>
 

--- a/interfaces/api/features/IKeypointDetectorRegion.h
+++ b/interfaces/api/features/IKeypointDetectorRegion.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_IKEYPOINTDETECTORREGION_H
 #define SOLAR_IKEYPOINTDETECTORREGION_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <memory>
 #include <vector>
 

--- a/interfaces/api/sink/ISinkPoseImage.h
+++ b/interfaces/api/sink/ISinkPoseImage.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ISINKPOSEIMAGE_H
 #define SOLAR_ISINKPOSEIMAGE_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include <xpcf/core/helpers.h>
 #include "ISinkReturnCode.h"

--- a/interfaces/api/sink/ISinkPoseTextureBuffer.h
+++ b/interfaces/api/sink/ISinkPoseTextureBuffer.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ISINKPOSETEXTUREBUFFER_H
 #define SOLAR_ISINKPOSETEXTUREBUFFER_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include <xpcf/core/helpers.h>
 #include "ISinkReturnCode.h"

--- a/interfaces/api/solver/map/IBundler.h
+++ b/interfaces/api/solver/map/IBundler.h
@@ -1,10 +1,6 @@
 #ifndef IBUNDLER_H
 #define IBUNDLER_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 
 // Definition of IMapFilter Class //
 // part of SolAR namespace //

--- a/interfaces/api/solver/map/IKeyframeSelector.h
+++ b/interfaces/api/solver/map/IKeyframeSelector.h
@@ -17,10 +17,6 @@
 #ifndef IKEYFRAMESELECTOR_H
 #define IKEYFRAMESELECTOR_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 // Definition of IMapFilter Class //
 // part of SolAR namespace //
 

--- a/interfaces/api/solver/map/IMapFilter.h
+++ b/interfaces/api/solver/map/IMapFilter.h
@@ -17,10 +17,6 @@
 #ifndef IMAPFILTER_H
 #define IMAPFILTER_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 // Definition of IMapFilter Class //
 // part of SolAR namespace //
 

--- a/interfaces/api/solver/map/IMapFusion.h
+++ b/interfaces/api/solver/map/IMapFusion.h
@@ -17,10 +17,6 @@
 #ifndef IMAPFUSION_H
 #define IMAPFUSION_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include "core/Messages.h"
 #include "datastructure/GeometryDefinitions.h"

--- a/interfaces/api/solver/map/IMapUpdate.h
+++ b/interfaces/api/solver/map/IMapUpdate.h
@@ -17,10 +17,6 @@
 #ifndef IMAPUPDATE_H
 #define IMAPUPDATE_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include <xpcf/core/helpers.h>
 #include "core/Messages.h"

--- a/interfaces/api/solver/map/ITriangulator.h
+++ b/interfaces/api/solver/map/ITriangulator.h
@@ -17,10 +17,6 @@
 #ifndef ITRIANGULATOR_H
 #define ITRIANGULATOR_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include <xpcf/core/helpers.h>
 #include "core/Messages.h"

--- a/interfaces/api/source/ISourceImage.h
+++ b/interfaces/api/source/ISourceImage.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ISOURCEIMAGE_H
 #define SOLAR_ISOURCEIMAGE_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include <xpcf/core/helpers.h>
 #include "ISourceReturnCode.h"

--- a/interfaces/api/storage/IMapManager.h
+++ b/interfaces/api/storage/IMapManager.h
@@ -17,10 +17,6 @@
 #ifndef IMAPMANAGER_H
 #define IMAPMANAGER_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 // Definition of IMapManager Class //
 // part of SolAR namespace //
 

--- a/interfaces/base/features/ADescriptorMatcher.h
+++ b/interfaces/base/features/ADescriptorMatcher.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ADESCRIPTORMATCHER_H
 #define SOLAR_ADESCRIPTORMATCHER_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include "core/SolARFrameworkDefinitions.h"
 #include <xpcf/component/ConfigurableBase.h>
 #include "api/features/IDescriptorMatcher.h"

--- a/interfaces/base/features/ADescriptorMatcherGeometric.h
+++ b/interfaces/base/features/ADescriptorMatcherGeometric.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ADESCRIPTORMATCHERGEOMETRIC_H
 #define SOLAR_ADESCRIPTORMATCHERGEOMETRIC_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include "core/SolARFrameworkDefinitions.h"
 #include "api/features/IDescriptorMatcherGeometric.h"
 #include <xpcf/component/ConfigurableBase.h>

--- a/interfaces/base/features/ADescriptorMatcherRegion.h
+++ b/interfaces/base/features/ADescriptorMatcherRegion.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ADESCRIPTORMATCHERREGION_H
 #define SOLAR_ADESCRIPTORMATCHERREGION_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include "core/SolARFrameworkDefinitions.h"
 #include "api/features/IDescriptorMatcherRegion.h"
 #include <xpcf/component/ConfigurableBase.h>

--- a/interfaces/base/features/ADescriptorMatcherStereo.h
+++ b/interfaces/base/features/ADescriptorMatcherStereo.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_ADESCRIPTORMATCHERSTEREO_H
 #define SOLAR_ADESCRIPTORMATCHERSTEREO_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include "core/SolARFrameworkDefinitions.h"
 #include "api/features/IDescriptorMatcherStereo.h"
 #include <xpcf/component/ConfigurableBase.h>

--- a/interfaces/base/geom/A2DPointsRectification.h
+++ b/interfaces/base/geom/A2DPointsRectification.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_A2DPOINTSRECTIFICATION_H
 #define SOLAR_A2DPOINTSRECTIFICATION_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include "core/SolARFrameworkDefinitions.h"
 #include <xpcf/component/ConfigurableBase.h>
 #include "api/geom/I2DPointsRectification.h"

--- a/interfaces/base/geom/AReprojectionStereo.h
+++ b/interfaces/base/geom/AReprojectionStereo.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_AREPROJECTIONSTEREO_H
 #define SOLAR_AREPROJECTIONSTEREO_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include "core/SolARFrameworkDefinitions.h"
 #include <xpcf/component/ConfigurableBase.h>
 #include "api/geom/IReprojectionStereo.h"

--- a/interfaces/base/pipeline/AMappingPipeline.h
+++ b/interfaces/base/pipeline/AMappingPipeline.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_AMAPPINGPIPELINE_H
 #define SOLAR_AMAPPINGPIPELINE_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include "core/SolARFrameworkDefinitions.h"
 #include <xpcf/component/ConfigurableBase.h>
 #include "api/pipeline/IMappingPipeline.h"

--- a/interfaces/core/SolARFramework.h
+++ b/interfaces/core/SolARFramework.h
@@ -17,16 +17,6 @@
 #ifndef SOLARFRAMEWORK_H
 #define SOLARFRAMEWORK_H
 
-#if _WIN32
-#ifdef SolARFramework_API_DLLEXPORT
-#define _BCOM_SHARED __declspec(dllexport)
-#else //_BCOM_SHARED
-#define _BCOM_SHARED __declspec(dllimport)
-#endif //_BCOM_SHARED
-#else //_WIN32
-#define _BCOM_SHARED
-#endif //_WIN32
-
 #include <string>
 
 #define _STR(x) #x
@@ -35,7 +25,7 @@
 namespace SolAR {
 
 /// \brief This method returns the version of the SolAR Framework
-_BCOM_SHARED std::string getSolARFrameworkVersion();
+SOLARFRAMEWORK_API std::string getSolARFrameworkVersion();
 
 }
 

--- a/interfaces/datastructure/CloudPoint.h
+++ b/interfaces/datastructure/CloudPoint.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_CLOUDPOINT_H
 #define SOLAR_CLOUDPOINT_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include <core/SolARFrameworkDefinitions.h>
 #include <datastructure/GeometryDefinitions.h>

--- a/interfaces/datastructure/Keypoint.h
+++ b/interfaces/datastructure/Keypoint.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_KEYPOINT_H
 #define SOLAR_KEYPOINT_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <core/SolARFrameworkDefinitions.h>
 #include <datastructure/GeometryDefinitions.h>
 #include <core/SerializationDefinitions.h>

--- a/interfaces/datastructure/Mesh.h
+++ b/interfaces/datastructure/Mesh.h
@@ -17,10 +17,6 @@
 #ifndef SOLAR_MESH_H
 #define SOLAR_MESH_H
 
-#ifndef _BCOM_SHARED
-#define _BCOM_SHARED
-#endif // _BCOM_SHARED
-
 #include <xpcf/api/IComponentIntrospect.h>
 #include <core/SolARFrameworkDefinitions.h>
 #include <core/SerializationDefinitions.h>

--- a/src/core/SolARFramework.cpp
+++ b/src/core/SolARFramework.cpp
@@ -16,7 +16,7 @@
 
 #include "core/SolARFramework.h"
 
-_BCOM_SHARED std::string getSolARFrameworkVersion(){
+SOLARFRAMEWORK_API std::string getSolARFrameworkVersion(){
 
     return STR(APP_VERSION);
 }


### PR DESCRIPTION
The role of this macro is to enable __declspec(dllexport)/ __declspec(dllimport) for Windows DLLs.

This feature is performed by the other macro SOLARFRAMEWORK_API which is enabled automatically by the remaken rules based the the qmake TARGET name (c.f. templatelibconfig.pri)

Defined in SolARFrameworkDefinitions.h