### PR TITLE
feat: add generated Version.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,4 +98,6 @@ bundle_system_install.sh
 *conanbuild*
 **/configure_conditions.pri
 
+# Generated headers
+interfaces/Version.h
 

--- a/SolARFramework.pri
+++ b/SolARFramework.pri
@@ -161,7 +161,8 @@ interfaces/base/pipeline/AMappingPipeline.h \
 interfaces/api/segm/IInstanceSegmentation.h \
 interfaces/api/segm/ISemanticSegmentation.h \
 interfaces/api/segm/IPanopticSegmentation.h \
-interfaces/api/display/IMaskOverlay.h
+interfaces/api/display/IMaskOverlay.h\
+interfaces/Version.h
 
 SOURCES += src/api/reloc/IKeyframeRetriever.cpp \
 src/datastructure/RelocalizationInformation.cpp \

--- a/SolARFramework.pro
+++ b/SolARFramework.pro
@@ -11,7 +11,6 @@ INSTALLSUBDIR = SolARBuild
 TARGET = SolARFramework
 FRAMEWORK = $$TARGET
 VERSION=1.3.0
-
 DEFINES += MYVERSION=$${VERSION}
 DEFINES += TEMPLATE_LIBRARY
 
@@ -42,6 +41,10 @@ include ($$shell_quote($$shell_path($${QMAKE_REMAKEN_RULES_ROOT}/templatelibconf
 msvc {
 DEFINES += "_BCOM_SHARED=__declspec(dllexport)"
 }
+
+genVersionHeader.input = $${PWD}/interfaces/Version.h.in
+genVersionHeader.output = $${PWD}/interfaces/Version.h
+QMAKE_SUBSTITUTES += genVersionHeader
 
 include (SolARFramework.pri)
 

--- a/interfaces/Version.h.in
+++ b/interfaces/Version.h.in
@@ -1,0 +1,29 @@
+/**
+ * @copyright Copyright (c) 2024 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SOLAR_VERSION_H
+#define SOLAR_VERSION_H
+
+#include <string>
+
+namespace SolAR
+{
+
+inline const std::string VERSION = \"$$VERSION\";
+
+}  // namespace SolAR
+
+#endif // SOLAR_VERSION_H


### PR DESCRIPTION
Allows to get SolAR version from code, avoiding to maintain hard-coded values.

Generated from the VERSION variable in the .pro file.