### PR TITLE
refactor: remove redundant parameter size from SquaredBinaryPattern::fromString

### DIFF
--- a/interfaces/datastructure/SquaredBinaryPattern.h
+++ b/interfaces/datastructure/SquaredBinaryPattern.h
@@ -56,7 +56,7 @@ public:
     /// \returns the size of the squared fiducial pattern to detect. If the marker is a square of size 7x7, we return 7.
     inline int getSize () const { return m_size; }
 
-    static SquaredBinaryPattern fromString(const std::string& str, int size);
+    static SquaredBinaryPattern fromString(const std::string& str);
 
 private :
     friend class boost::serialization::access;

--- a/src/datastructure/SquaredBinaryPattern.cpp
+++ b/src/datastructure/SquaredBinaryPattern.cpp
@@ -17,6 +17,7 @@
 #include "datastructure/SquaredBinaryPattern.h"
 #include "core/Log.h"
 #include "xpcf/core/helpers.h"
+#include <cmath>
 #include <iostream>
 
 namespace SolAR {
@@ -46,13 +47,16 @@ FrameworkReturnCode SquaredBinaryPattern::setPatternMatrix (const SquaredBinaryP
     return FrameworkReturnCode::_SUCCESS;
 };
 
- SquaredBinaryPattern SquaredBinaryPattern::fromString(const std::string& str, int size) {
-    assert(str.length() == size * size);
+ SquaredBinaryPattern SquaredBinaryPattern::fromString(const std::string& str) {
+    auto size = static_cast<size_t>(std::round(std::sqrt(str.length())));
+    if ( str.length() != size * size ) {
+         return SquaredBinaryPattern();
+    }
 
     SquaredBinaryPatternMatrix matrix(size, size);
 
-    for (int i = 0; i < size; ++i) {
-        for (int j = 0; j < size; ++j) {
+    for (size_t i = 0; i < size; ++i) {
+        for (size_t j = 0; j < size; ++j) {
             matrix(i, j) = str[i * size + j] == '1';
         }
     }

--- a/src/datastructure/StorageTrackable.cpp
+++ b/src/datastructure/StorageTrackable.cpp
@@ -110,10 +110,14 @@ namespace datastructure {
             std::bitset<1> bits(static_cast<unsigned char>(byte));
             str += bits.to_string();
         }
-        SquaredBinaryPattern payload = SquaredBinaryPattern::fromString(str,6);
+        SquaredBinaryPattern payload = SquaredBinaryPattern::fromString(str);
+        auto sbpSize = payload.getSize();
+        if (sbpSize == 0) { LOG_ERROR("Failed to build Trackable payload from string '{}'. Pattern must define a square shape.", str); }
+        else if (sbpSize != 6) { LOG_ERROR("Trackable of unsupported size '{}', must be 6", sbpSize); }
+        // TODO: manage error + see how to support other sizes of marker
         Sizef pattern_size;
-        pattern_size.width = 6;
-        pattern_size.height = 6;
+        pattern_size.width = sbpSize;
+        pattern_size.height = sbpSize;
         SRef<FiducialMarker> result = xpcf::utils::make_shared<FiducialMarker>(trackable.getName(), pattern_size, payload);
         result->setTransform3D(trackable.m_localCRS);
 


### PR DESCRIPTION
This parameter can be deduced from 'str', so there's no need to pass it.

This will prevent errors due to size actually not matching the actual length of the string.