### PR TITLE
fix(Lockable): add [[nodiscard]] attribute to acquireLock()

### DIFF
--- a/interfaces/datastructure/Lockable.h
+++ b/interfaces/datastructure/Lockable.h
@@ -42,6 +42,7 @@ class  SOLARFRAMEWORK_API Lockable {
 		/// @brief This method returns the point cloud
         /// @return the lock preventing concurrent access to the PointCloud set
 		///
+        [[nodiscard]]
         std::unique_lock<std::mutex> acquireLock() {
             return std::unique_lock<std::mutex>(m_mutex);
         }


### PR DESCRIPTION
Not using the return value of acquireLock() essentially means that this method does nothing.

We should also consider treating `-Wunused-result` as an error.